### PR TITLE
Added uuids to testsession and server run serializers

### DIFF
--- a/src/vng/servervalidation/serializers.py
+++ b/src/vng/servervalidation/serializers.py
@@ -50,7 +50,8 @@ class ServerRunSerializer(serializers.ModelSerializer):
             'endpoints',
             'status',
             'percentage_exec',
-            'status_exec'
+            'status_exec',
+            'uuid'
         ]
         read_only_fields = ['id', 'started', 'stopped', 'status']
 

--- a/src/vng/testsession/serializers.py
+++ b/src/vng/testsession/serializers.py
@@ -84,7 +84,8 @@ class SessionSerializer(serializers.ModelSerializer):
             'status',
             'exposedurl_set',
             'build_version',
-            'sandbox'
+            'sandbox',
+            'uuid'
         ]
         read_only_fields = ['started', 'stopped', 'status']
 


### PR DESCRIPTION
@alextreme dit is zodat ik de uuid kan opslaan bij de tests voor de API van het API test platform (https://github.com/VNG-Realisatie/api-test-platform/issues/180), omdat er bij het ophalen van de shields het `TestSession`/`ServerRun` `uuid` opgegeven moet worden (https://github.com/VNG-Realisatie/api-test-platform-code/blob/master/src/vng/testsession/api_views.py#L532)

Is er specifiek een reden waarom dit nu met een `uuid` gebeurt i.p.v. `id`?