### PR TITLE
Ordered Scenario cases by collection and OrderedModel order

### DIFF
--- a/src/vng/testsession/admin.py
+++ b/src/vng/testsession/admin.py
@@ -109,6 +109,7 @@ class ScenarioCaseAdmin(OrderedModelAdmin):
         'collection'
     ]
     inlines = [QueryParamsScenarioInline]
+    ordering = ('collection', 'order',)
 
 
 @admin.register(model.QueryParamsScenario)


### PR DESCRIPTION
because it did not update the order in the admin when moving scenario cases up or down