### PR TITLE
Fixed KeyError for schemageneration

### DIFF
--- a/src/vng/testsession/api_views.py
+++ b/src/vng/testsession/api_views.py
@@ -112,7 +112,11 @@ class StopSessionView(generics.ListAPIView):
         run_tests.delay(session.pk)
 
     def get_queryset(self):
-        session = get_object_or_404(Session, id=self.kwargs['pk'])
+        pk = self.kwargs.get('pk')
+        if not pk:
+            return ScenarioCase.objects.none()
+
+        session = get_object_or_404(Session, id=pk)
         scenarios = session.session_type.scenario_cases
         if session.user != self.request.user:
             return HttpResponseForbidden()


### PR DESCRIPTION
to stop [this error](https://sentry.maykinmedia.nl/maykin-media/vng-testplatform-staging/issues/258891/) from occurring upon schema generation 