### PR TITLE
Hide marked variables in server run PDF report

### DIFF
--- a/src/vng/servervalidation/templates/servervalidation/server-run-PDF.html
+++ b/src/vng/servervalidation/templates/servervalidation/server-run-PDF.html
@@ -11068,7 +11068,13 @@
                             {% for ep in object.endpoint_set.all %}
                             <tr>
                                 <td>{{ ep.test_scenario_url.name }}</td>
-                                <td>{{ ep.url }}</td>
+                                <td>
+                                    {% if not ep.test_scenario_url.hidden %}
+                                        {{ ep.url }}
+                                    {% else %}
+                                        <i>{% trans "This field was marked as hidden" %}</i>
+                                    {% endif %}
+                                </td>
                             </tr>
                             {% endfor %}
 


### PR DESCRIPTION
I forgot to hide the variables in the PDF report