### PR TITLE
Feature/badge endpoint for ci

### DIFF
--- a/src/vng/servervalidation/api_views.py
+++ b/src/vng/servervalidation/api_views.py
@@ -1,4 +1,4 @@
-
+from datetime import date
 import json
 
 from django.shortcuts import get_object_or_404
@@ -29,7 +29,7 @@ from .task import execute_test
 from ..utils import choices
 
 
-def get_server_run_badge(server_run):
+def get_server_run_badge(server_run, label):
     res = server_run.get_execution_result()
     is_error = True
     if res is None:
@@ -44,7 +44,7 @@ def get_server_run_badge(server_run):
         color = 'red'
     result = {
         'schemaVersion': 1,
-        'label': 'API Test Platform (beta)',
+        'label': label,
         'message': message,
         'color': color,
         'isError': is_error,
@@ -117,7 +117,8 @@ class ResultServerViewShield(views.APIView):
     @swagger_auto_schema(responses={200: ServerRunResultShield})
     def get(self, request, uuid=None):
         server = get_object_or_404(ServerRun, uuid=uuid)
-        return JsonResponse(get_server_run_badge(server))
+        date_stopped = date.strftime(server.stopped, '%Y-%m-%d %H:%m:%S')
+        return JsonResponse(get_server_run_badge(server, 'API Test Platform (beta) {}'.format(date_stopped)))
 
 
 class ResultServerView(views.APIView):
@@ -245,4 +246,4 @@ class ServerRunLatestResultView(views.APIView):
         ).order_by('-stopped').first()
         if not latest_server_run:
             raise Http404
-        return JsonResponse(get_server_run_badge(latest_server_run))
+        return JsonResponse(get_server_run_badge(latest_server_run, 'API Test Platform (beta)'))

--- a/src/vng/servervalidation/api_views.py
+++ b/src/vng/servervalidation/api_views.py
@@ -16,6 +16,7 @@ from rest_framework.decorators import action
 from rest_framework.authentication import (
     SessionAuthentication, TokenAuthentication
 )
+from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 
 import vng.postman.utils as ptm
@@ -214,8 +215,29 @@ class PostmanTestViewset(mixins.ListModelMixin,
 
 
 class ServerRunLatestResultView(views.APIView):
+    """
+    Retrieve the latest badge for a test scenario
 
-    @swagger_auto_schema(responses={200: ServerRunResultShield})
+    Return the badge information of the latest provider run given a combination of
+    test scenario name and username of the user that starten the provider run
+    """
+
+    @swagger_auto_schema(
+        responses={200: ServerRunResultShield},
+        manual_parameters=[
+            openapi.Parameter(
+                'name',
+                openapi.IN_PATH,
+                type=openapi.TYPE_STRING,
+                description='Name of the test scenario'
+            ),
+            openapi.Parameter(
+                'user',
+                openapi.IN_PATH,
+                type=openapi.TYPE_STRING,
+                description='Name of the user that started the provider run for the test scenario'
+            ),
+        ])
     def get(self, request, name, user):
         latest_server_run = ServerRun.objects.filter(
             test_scenario__name=name,

--- a/src/vng/servervalidation/templates/servervalidation/server-run_detail.html
+++ b/src/vng/servervalidation/templates/servervalidation/server-run_detail.html
@@ -32,8 +32,61 @@
         </div>
         <div class="col-sm-6">
             <div class="card">
+                <div class="card-header">
+                    {% trans "Test scenario badge" %}
+                </div>
+                <div class="card-body">
+                    <p>Shown below is the badge of the most recent provider run that was started by the user <b>{{ object.user }}</b></p>
+                    <p>
+                        {% comment %} {% url 'apiv1server:latest-badge' object.uuid as addr %} {% endcomment %}
+                        {% blocktrans %}
+                            Note: Shields.io caches the badge result for 5 minutes. Check the <a
+                                href="{{url}}">API</a> for
+                            direct access.
+                        {% endblocktrans %}
+                    </p>
+                    <span display="block" style='width: 250px;' class="common__BadgeWrapper-sc-16zh6vt-3 fagfmg">
+                        <a href="{% url 'server_run:server-run_detail_uuid' object.uuid %}">
+
+                            <img style='width:250px' alt=""
+                                src="https://img.shields.io/endpoint.svg?style=for-the-badge&amp;url={{changing_badge_url|urlencode}}">
+                        </a>
+                    </span>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-body">
+                    {% blocktrans %}
+                        <h5 class="card-title">Markdown snippet</h5>
+                        <p>Paste the following in your README.md to show your badge on Github.</p>
+                        <?prettify lang=html linenums=true?>
+                    {% endblocktrans %}
+                        <pre class="prettyprint" id='gitSnippet_changing'>
+                    <xmp>
+                    </xmp>
+                    </pre>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-body">
+                    {% blocktrans %}
+                        <h5 class="card-title">HTML snippet</h5>
+                        <p>Paste the following in your HTML page to show your badge.</p>
+                        <?prettify lang=html linenums=true?>
+                    {% endblocktrans %}
+                        <pre class="prettyprint" id='htmlSnippet_changing'>
+                    <xmp>
+                    </xmp>
+                    </pre>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-header">
+                    {% trans "Provider run badge" %}
+                </div>
                 <div class="card-body">
                     <p>
+                        <p>Shown below is the persistent badge for this specific provider run</p>
                         {% url 'apiv1server:api_server-run-shield-detail' object.uuid as addr%}
                         {% blocktrans %}
                             Note: Shields.io caches the badge result for 5 minutes. Check the <a
@@ -56,23 +109,22 @@
                         <p>Paste the following in your README.md to show your badge on Github.</p>
                         <?prettify lang=html linenums=true?>
                     {% endblocktrans %}
-                        <pre class="prettyprint" id='gitSnippet'>
+                        <pre class="prettyprint" id='gitSnippet_persistent'>
                     <xmp>
-
                     </xmp>
                     </pre>
                 </div>
-                </div>
-                <div class="card">
-                    <div class="card-body">
-                        {% blocktrans %}
-                            <h5 class="card-title">HTML snippet</h5>
-                            <p>Paste the following in your HTML page to show your badge.</p>
-                            <?prettify lang=html linenums=true?>
-                        {% endblocktrans %}
-                            <pre class="prettyprint" id='htmlSnippet'>
-                        <xmp>
-                        </xmp>
+            </div>
+            <div class="card">
+                <div class="card-body">
+                    {% blocktrans %}
+                        <h5 class="card-title">HTML snippet</h5>
+                        <p>Paste the following in your HTML page to show your badge.</p>
+                        <?prettify lang=html linenums=true?>
+                    {% endblocktrans %}
+                        <pre class="prettyprint" id='htmlSnippet_persistent'>
+                    <xmp>
+                    </xmp>
                     </pre>
                     </div>
                 </div>
@@ -362,13 +414,6 @@
 
 {% block script %}
 <script>
-    var gitSnippet = '[![Status badge](https://img.shields.io/endpoint.svg?style=for-the-badge&amp;url={{request.scheme}}://{{request.get_host}}{% url "apiv1server:api_server-run-shield" object.uuid %})]({{request.scheme}}://{{request.get_host}}{% url 'server_run:server-run_detail_uuid' object.uuid %})'
-
-    var htmlSnippet = '<span display="block" height="20px" class="common__BadgeWrapper-sc-16zh6vt-3 fagfmg">\n'
-            + '<a href="{{request.scheme}}://{{request.get_host}}{% url 'server_run:server-run_detail_uuid' object.uuid %}">\n'
-            + '<img style="width:100%" alt="" src="https://img.shields.io/endpoint.svg?style=for-the-badge&\n '
-            + 'url={{request.scheme}}://{{request.get_host}}{% url "apiv1server:api_server-run-shield" object.uuid %}"></span></a>'
-
     function htmlEscape(s) {
         s = s.replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
@@ -383,18 +428,45 @@
         return s;
     }
 
+    var gitSnippet_changing = '[![Status badge](https://img.shields.io/endpoint.svg?style=for-the-badge&amp;url={{changing_badge_url|urlencode}})]({{changing_badge_url|urlencode}})'
+
+    var htmlSnippet_changing = '<span display="block" height="20px" class="common__BadgeWrapper-sc-16zh6vt-3 fagfmg">\n'
+            + '<a href="{{request.scheme}}://{{request.get_host}}{% url 'server_run:server-run_detail_uuid' object.uuid %}">\n'
+            + '<img style="width:100%" alt="" src="https://img.shields.io/endpoint.svg?style=for-the-badge&\n '
+            + 'url={{changing_badge_url|urlencode}}"></span></a>'
+
     // this page's own source code
-    gitSnippet = htmlEscape(gitSnippet);
-    gitSnippet = htmlReplace(gitSnippet);
+    gitSnippet_changing = htmlEscape(gitSnippet_changing);
+    gitSnippet_changing = htmlReplace(gitSnippet_changing);
 
 
-    htmlSnippet = htmlEscape(htmlSnippet);
-    htmlSnippet = htmlReplace(htmlSnippet);
+    htmlSnippet_changing = htmlEscape(htmlSnippet_changing);
+    htmlSnippet_changing = htmlReplace(htmlSnippet_changing);
 
 
     // insert into PRE
-    document.getElementById("gitSnippet").innerHTML = gitSnippet;
-    document.getElementById("htmlSnippet").innerHTML = htmlSnippet;
+    document.getElementById("gitSnippet_changing").innerHTML = gitSnippet_changing;
+    document.getElementById("htmlSnippet_changing").innerHTML = htmlSnippet_changing;
 
+
+    var gitSnippet_persistent = '[![Status badge](https://img.shields.io/endpoint.svg?style=for-the-badge&amp;url={{request.scheme}}://{{request.get_host}}{% url "apiv1server:api_server-run-shield" object.uuid %})]({{request.scheme}}://{{request.get_host}}{% url 'server_run:server-run_detail_uuid' object.uuid %})'
+
+    var htmlSnippet_persistent = '<span display="block" height="20px" class="common__BadgeWrapper-sc-16zh6vt-3 fagfmg">\n'
+            + '<a href="{{request.scheme}}://{{request.get_host}}{% url 'server_run:server-run_detail_uuid' object.uuid %}">\n'
+            + '<img style="width:100%" alt="" src="https://img.shields.io/endpoint.svg?style=for-the-badge&\n '
+            + 'url={{request.scheme}}://{{request.get_host}}{% url "apiv1server:api_server-run-shield" object.uuid %}"></span></a>'
+
+    // this page's own source code
+    gitSnippet_persistent = htmlEscape(gitSnippet_persistent);
+    gitSnippet_persistent = htmlReplace(gitSnippet_persistent);
+
+
+    htmlSnippet_persistent = htmlEscape(htmlSnippet_persistent);
+    htmlSnippet_persistent = htmlReplace(htmlSnippet_persistent);
+
+
+    // insert into PRE
+    document.getElementById("gitSnippet_persistent").innerHTML = gitSnippet_persistent;
+    document.getElementById("htmlSnippet_persistent").innerHTML = htmlSnippet_persistent;
 </script>
 {% endblock %}

--- a/src/vng/servervalidation/tests/factories.py
+++ b/src/vng/servervalidation/tests/factories.py
@@ -57,6 +57,7 @@ class PostmanTestFactory(Dmf):
         model = PostmanTest
     test_scenario = factory.SubFactory(TestScenarioFactory)
     validation_file = factory.SubFactory(FilerField)
+    name = factory.Sequence(lambda n: "Postman test %d" % n)
 
 
 class PostmanTestSubFolderFactory(Dmf):

--- a/src/vng/servervalidation/urls_api.py
+++ b/src/vng/servervalidation/urls_api.py
@@ -16,6 +16,7 @@ router.register('postman-test', api_views.PostmanTestViewset, base_name='api_pos
 
 urlpatterns = [
     path('provider-run-shield/<uuid:uuid>/', api_views.ResultServerViewShield.as_view(), name='api_server-run-shield'),
+    re_path(r'provider-latest-badge/(?P<name>[^/.]+)/(?P<user>[^/.]+)/', api_views.ServerRunLatestResultView.as_view(), name='latest-badge'),
     re_path(r'schema/openapi(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     path('schema', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
     path('provider-run/<int:pk>/trigger/', api_views.TriggerServerRunView.as_view({'put': 'update'}), name='provider'),

--- a/src/vng/servervalidation/views.py
+++ b/src/vng/servervalidation/views.py
@@ -226,6 +226,15 @@ class ServerRunOutputUuid(DetailView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         server_run = context['object']
+
+        # Construct the URL of the changing badge
+        changing_badge_url = '{}://{}{}'.format(
+            self.request.scheme,
+            self.request.get_host(),
+            reverse('apiv1server:latest-badge', kwargs={'name': server_run.test_scenario.name, 'user': server_run.user})
+        )
+        context['changing_badge_url'] = changing_badge_url
+
         ptr = PostmanTestResult.objects.filter(server_run=server_run)
         context["postman_result"] = ptr
         context["update_info"] = True


### PR DESCRIPTION
voor https://github.com/VNG-Realisatie/api-test-platform/issues/267

Ik heb alvast een API endpoint toegevoegd waar je op basis van test scenario en username de badge details van de meest recente server run terugkrijgt, zodat je met een enkele url die niet verandert altijd de laatste badge gegevens hebt op Github.