### PR TITLE
Changed scheduled test email message

### DIFF
--- a/src/vng/servervalidation/task.py
+++ b/src/vng/servervalidation/task.py
@@ -138,7 +138,7 @@ def send_email_failure(sl):
     })
 
     send_mail(
-        _('Failure of scheduled test'),
+        _('Results of scheduled tests'),
         msg_html,
         settings.DEFAULT_FROM_EMAIL,
         [sl[0][0].user.email],

--- a/src/vng/servervalidation/templates/servervalidation/failed_test_email.html
+++ b/src/vng/servervalidation/templates/servervalidation/failed_test_email.html
@@ -2,8 +2,9 @@
     Dear Sir/Mrs,
     <br>
     One or more scheduled tests have failed, you can find all the details below.
+    Below are the results of the scheduled tests that have been run by the API Test Platform
     <br>
-    You are receiving this e-mail because you configured one or more scheduled provider tests in the VNG API Test platform.
+    You are receiving this e-mail because you configured one or more scheduled provider tests in the VNG API Test Platform.
 </p>
 <p>
 {% if failure %}


### PR DESCRIPTION
voor https://github.com/VNG-Realisatie/api-test-platform/issues/280

niet heel ingrijpend, maar voorkomt toch wat verwarring als alle tests geslaagd zijn