### PR TITLE
Issue/query params scenario on post request

### DIFF
--- a/src/vng/testsession/api_views.py
+++ b/src/vng/testsession/api_views.py
@@ -249,10 +249,7 @@ class RunTest(CSRFExemptMixin, View):
         logger.info("Parsed: %s", parsed_url)
         logger.info("URL: %s", check_url)
         if re.search(parsed_url, check_url) is not None:
-            if self.request.method == 'POST':
-                params = self.request.POST
-            else:
-                params = self.request.GET
+            params = self.request.GET
             for qp in query_params:
                 par = params.get(qp.name)
                 if par is None or (qp.expected_value != '*' and qp.expected_value != par):


### PR DESCRIPTION
probleem deed zich voor dat de scenario cases voor post requests met query params niet gelogd werden ([zaak__zoek operatie in ZRC](https://zaken-api.vng.cloud/api/v1/schema/#operation/zaak__zoek))