### PR TITLE
Fix docker install with ansible

### DIFF
--- a/deployment/tasks/shields.yml
+++ b/deployment/tasks/shields.yml
@@ -11,14 +11,12 @@
     repo: deb https://download.docker.com/linux/ubuntu bionic stable
     state: present
 
-- name: Update apt and install containerd.io
-  apt: update_cache=yes name=containerd.io state=latest
-
-- name: Update apt and install docker-ce-cli
-  apt: update_cache=yes name=docker-ce-cli state=latest
-
-- name: Update apt and install docker-ce
-  apt: update_cache=yes name=docker-ce state=latest
+- name: Install docker
+    apt: name={{item}} state=present update_cache=yes
+    with_items:
+    - docker-ce
+    - containerd.io
+    - docker-ce-cli
 
 - name: Install Docker Module for Python
   pip:


### PR DESCRIPTION
@alextreme Het installeren van docker lukt nog niet via ansible

```
FAILED! => {"cache_update_time": 1573139664, "cache_updated": true, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'containerd.io'' failed: E: Unable to correct problems, you have held broken packages.\n", "rc": 100, "stderr": "E: Unable to correct problems, you have held broken packages.\n", "stderr_lines": ["E: Unable to correct problems, you have held broken packages."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n containerd.io : Depends: libseccomp2 (>= 2.4.0) but 2.3.3-4 is to be installed\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "Some packages could not be installed. This may mean that you have", "requested an impossible situation or if you are using the unstable", "distribution that some required packages have not yet been created", "or been moved out of Incoming.", "The following information may help to resolve the situation:", "", "The following packages have unmet dependencies:", " containerd.io : Depends: libseccomp2 (>= 2.4.0) but 2.3.3-4 is to be installed"]}
```