### PR TITLE
Limit filename to 100 chars in datamigration for postman test files

### DIFF
--- a/src/vng/servervalidation/migrations/0094_auto_20191108_1257.py
+++ b/src/vng/servervalidation/migrations/0094_auto_20191108_1257.py
@@ -7,7 +7,11 @@ from filer.models import File
 def migrate_postmantest_validation_files(apps, schema_editor):
     PostmanTest = apps.get_model('servervalidation', 'PostmanTest')
     for postmantest in PostmanTest.objects.all():
-        postmantest.validation_file = postmantest._validation_file.file
+        validation_file = postmantest._validation_file.file
+
+        # To ensure that the name of the file is no longer than 100 characters
+        validation_file.name = validation_file.name.split('/')[-1][:100]
+        postmantest.validation_file = validation_file
         postmantest.save()
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
should fix https://sentry.maykinmedia.nl/maykin-media/vng-testplatform-staging/issues/262083/