### PR TITLE
Feature/delete variables and postman tests from test scenario

### DIFF
--- a/src/vng/servervalidation/forms.py
+++ b/src/vng/servervalidation/forms.py
@@ -148,6 +148,14 @@ TestScenarioUrlFormSet = inlineformset_factory(
     extra=0
 )
 
+TestScenarioUrlUpdateFormSet = inlineformset_factory(
+    TestScenario,
+    TestScenarioUrl,
+    form=CreateTestScenarioUrlForm,
+    can_delete=True,
+    extra=0
+)
+
 
 class UploadPostmanTestForm(forms.ModelForm):
 
@@ -163,6 +171,14 @@ PostmanTestFormSet = inlineformset_factory(
     PostmanTest,
     form=UploadPostmanTestForm,
     can_delete=False,
+    extra=0
+)
+
+PostmanTestUpdateFormSet = inlineformset_factory(
+    TestScenario,
+    PostmanTest,
+    form=UploadPostmanTestForm,
+    can_delete=True,
     extra=0
 )
 

--- a/src/vng/servervalidation/templates/servervalidation/test_scenario-form.html
+++ b/src/vng/servervalidation/templates/servervalidation/test_scenario-form.html
@@ -84,16 +84,25 @@
 <script>
     function addForm(formset) {
         if(formset == 'variables') {
-            var formset_id = '#form_set_variables'
-            var prefix = '#id_testscenariourl_set'
-            var empty_form_id = '#empty_form_variables'
+            var formset_id = 'form_set_variables';
+            var prefix = '#id_testscenariourl_set';
+            var empty_form_id = 'empty_form_variables';
         } else if(formset == 'postman') {
-            var formset_id = '#form_set_postman'
-            var prefix = '#id_postmantest_set'
-            var empty_form_id = '#empty_form_postman'
+            var formset_id = 'form_set_postman';
+            var prefix = '#id_postmantest_set';
+            var empty_form_id = 'empty_form_postman';
         }
         var form_idx = document.querySelector(prefix+'-TOTAL_FORMS').value;
-        document.querySelector(formset_id).innerHTML += document.querySelector(empty_form_id).innerHTML.replace(/__prefix__/g, form_idx);
+
+        var empty_form = document.getElementById(empty_form_id).cloneNode(true);
+        empty_form.innerHTML = empty_form.innerHTML.replace(/__prefix__/g, form_idx);
+        empty_form.className = "form-group";
+        empty_form.style.display = "";
+        empty_form.removeAttribute("id");
+
+        // Appendchild to avoid resetting data that was entered in the other
+        // forms in the formset by the user
+        document.getElementById(formset_id).appendChild(empty_form);
         document.querySelector(prefix+'-TOTAL_FORMS').value = parseInt(form_idx) + 1;
     }
 </script>


### PR DESCRIPTION
het verwijderen van bestaande urls of postmantests was namelijk nog niet mogelijk.

Er was ook een bug waardoor er bij het klikken op de knop om een nieuw form toe te voegen voor de inline formsets, de al eerder ingevulde data gereset werd, dat is bij deze ook gefixed