### PR TITLE
Issue/testscenario form postman test file validation

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,7 +16,7 @@ django-sniplates
 django-redis
 -e git+git://github.com/maykinmedia/django-admin-index@master#egg=django_admin_index
 django-import-export
-django-crispy-forms
+django-crispy-forms>=1.8.0
 django-countries
 djangorestframework-filters
 django-solo

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ django-choices==1.6.1
 django-ckeditor==5.7.1
 django-compat==1.0.15     # via django-background-tasks, django-hijack, django-hijack-admin
 django-countries==5.3.2
-django-crispy-forms==1.7.2
+django-crispy-forms==1.8.0
 django-dynamic-raw-id==2.4
 django-filer==1.5.0
 django-filter==1.1.0      # via djangorestframework-filters

--- a/src/vng/servervalidation/tests/test_configuration_test_scenario.py
+++ b/src/vng/servervalidation/tests/test_configuration_test_scenario.py
@@ -266,6 +266,26 @@ class TestScenarioCreateTests(WebTest):
 
         self.assertNotIn('Configure test scenarios', response.text)
 
+    def test_create_postman_test_file_validation(self):
+        response = self.app.get(reverse('server_run:test-scenario_create_item', kwargs={
+            'api_id': self.api.id
+        }), {"extra": 1}, user=self.user)
+
+        form = response.forms[1]
+        form['name'] = 'some scenario name'
+        form['description'] = 'test description'
+        form['public_logs'] = False
+
+        form['postmantest_set-0-name'] = 'sometestscript'
+        form['postmantest_set-0-version'] = '1.0.2'
+
+        form['postmantest_set-0-published_url'] = 'https://example.com'
+
+        response = form.submit()
+
+        error_div = response.html.find('p', {'id': 'error_1_id_postmantest_set-0-validation_file'})
+        self.assertIn('required', error_div.text)
+
 
 class TestScenarioUpdateTests(WebTest):
 

--- a/src/vng/servervalidation/views.py
+++ b/src/vng/servervalidation/views.py
@@ -713,6 +713,7 @@ class TestScenarioUpdateView(ObjectPermissionMixin, PermissionRequiredMixin, Log
 
         context = {}
         context['api'] = API.objects.get(id=self.kwargs['api_id'])
+        context['object'] = self.get_object()
         context['form'] = form
         context['variables'] = variable_form
         context['postman_tests'] = postman_form


### PR DESCRIPTION
voor https://github.com/VNG-Realisatie/api-test-platform/issues/317

de upgrade naar 1.8.0 van `django-crispy-forms` zorgt ervoor dat er bij het aanmaken van een testscenario met postmantest zonder file wel een error weergegeven bij de correcte input. Deze versie van `django-crispy-forms` heeft echter nog wel wat problemen qua display van de naam van de geuploade file, maar dit zal gefixed worden in 1.8.1 (https://github.com/django-crispy-forms/django-crispy-forms/issues/918#issuecomment-554930284)