### PR TITLE
Increased timeout-request for newman runner

### DIFF
--- a/src/vng/utils/newman.py
+++ b/src/vng/utils/newman.py
@@ -19,7 +19,7 @@ class NewmanManager:
     newman_path = os.path.join(settings.BASE_DIR, 'node_modules', 'newman', 'bin', 'newman.js')
     RUN_REPORT = ('NODE_OPTIONS="--max-old-space-size=2048" '
                        '{} run --reporters "htmlextra,json" {} '
-                       '--timeout-request 5000 '
+                       '--timeout-request 50000 '
                        '--reporter-htmlextra-darkTheme '
                        '--reporter-htmlextra-testPaging '
                        '--reporter-htmlextra-title '


### PR DESCRIPTION
for https://github.com/VNG-Realisatie/api-test-platform/issues/265#issuecomment-560433408

aangezien de requests naar de referentiecomponenten soms 25 seconden kunnen duren :)