### PR TITLE
Bump django to 2.2.8

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,7 +4,7 @@ Pillow>=6.2.0
 pytz
 raven
 
-Django==2.2.4
+Django>=2.2.8
 # django-admin-tools
 django-hijack
 django-hijack-admin

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,7 +51,7 @@ django-rosetta==0.9.0
 django-sniplates==0.6.0
 django-solo==1.1.3
 django-tinymce==2.8.0
-django==2.2.4
+django==2.2.8
 djangorestframework-filters==0.10.2.post0
 djangorestframework==3.9.4
 drf-yasg==1.13.0


### PR DESCRIPTION
naar aanleiding van https://github.com/VNG-Realisatie/api-test-platform-code/network/alert/requirements/base.txt/django/open