### PR TITLE
Mark assertion as failed if errors occur in post request script

### DIFF
--- a/src/vng/postman/utils.py
+++ b/src/vng/postman/utils.py
@@ -31,6 +31,10 @@ def get_call_result(call):
     # if the response is not present it means that it has not been performed
     if 'response' not in call or 'code' not in call['response']:
         return False
+
+    # check for errors in the script
+    if any(script for script in call.get("testScript", []) if 'error' in script):
+        return False
     return ('error_test' not in call['item'] or not call['item']['error_test'])
 
 

--- a/src/vng/servervalidation/models.py
+++ b/src/vng/servervalidation/models.py
@@ -367,6 +367,11 @@ class PostmanTestResult(models.Model):
     def get_call_results(self):
         positive, negative = 0, 0
         for call in self.get_json_obj():
+            if 'testScript' in call:
+                for script in call['testScript']:
+                    if 'error' in script:
+                        negative += 1
+
             # Count the failed and successful assertions
             if 'assertions' in call:
                 for assertion in call['assertions']:
@@ -383,6 +388,11 @@ class PostmanTestResult(models.Model):
             success = True
             if not postman.get_call_result(call):
                 success = False
+            if 'testScript' in call:
+                for script in call['testScript']:
+                    if 'error' in script:
+                        error += 1
+                        success = False
             if 'assertions' in call:
                 for assertion in call['assertions']:
                     if 'error' in assertion:

--- a/src/vng/servervalidation/tests/test_postmantestresult.py
+++ b/src/vng/servervalidation/tests/test_postmantestresult.py
@@ -75,3 +75,22 @@ class PostmanTestResultTests(TestCase):
             'assertions': {'passed': 1, 'failed': 1, 'total': 2},
             'calls': {'success': 0, 'failed': 1, 'total': 1}
         })
+
+    def test_get_aggregated_results_test_script_errors(self):
+        ptr = PostmanTestResultFactory.create(log_json=SimpleUploadedFile('test.json', b'''
+            {
+                "run": {
+                    "executions": [{
+                        "request": {"url": "test"}, "response": {"code": 400}, "item": {"error_test": true},
+                        "testScript": [{"error": "bla"}, {}]
+                    }],
+                    "timings": {"started": "100", "stopped": "200"}
+                }
+            }
+        '''))
+        res = ptr.get_aggregate_results()
+
+        self.assertDictEqual(res, {
+            'assertions': {'passed': 0, 'failed': 1, 'total': 1},
+            'calls': {'success': 0, 'failed': 1, 'total': 1}
+        })


### PR DESCRIPTION
naar aanleiding van issue https://github.com/VNG-Realisatie/api-test-platform/issues/330

@alextreme Newman merkt de assertions niet aan als gefaald, doordat de runner er niet eens bijkomt door een Javascript error