### PR TITLE
Pin coverage to 4.5.4 for jenkins

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,6 +1,6 @@
 # Shared between dev and jenkins requirements to run our tests
 astroid==2.2.5
-coverage
+coverage==4.5.4
 django-webtest
 factory_boy
 freezegun


### PR DESCRIPTION
@alextreme jenkins faalt nu op alles doordat coverage naar 5.0.0 geupdate is:

http://jenkins.maykin.nl/job/VNG%20Github/job/api-test-platform-code/view/change-requests/job/PR-292/3/console
```html
Traceback (most recent call last):
  File "src/manage.py", line 27, in <module>
    execute_from_command_line(sys.argv)
  File "/tmp/jenkins-slave/workspace/ub_api-test-platform-code_PR-292/env/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/tmp/jenkins-slave/workspace/ub_api-test-platform-code_PR-292/env/lib/python3.7/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/tmp/jenkins-slave/workspace/ub_api-test-platform-code_PR-292/env/src/django-jenkins/django_jenkins/management/commands/jenkins.py", line 47, in run_from_argv
    super(Command, self).run_from_argv(argv)
  File "/tmp/jenkins-slave/workspace/ub_api-test-platform-code_PR-292/env/lib/python3.7/site-packages/django/core/management/commands/test.py", line 23, in run_from_argv
    super().run_from_argv(argv)
  File "/tmp/jenkins-slave/workspace/ub_api-test-platform-code_PR-292/env/lib/python3.7/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/tmp/jenkins-slave/workspace/ub_api-test-platform-code_PR-292/env/lib/python3.7/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/tmp/jenkins-slave/workspace/ub_api-test-platform-code_PR-292/env/src/django-jenkins/django_jenkins/management/commands/jenkins.py", line 116, in handle
    coverage.save(tested_locations, options)
  File "/tmp/jenkins-slave/workspace/ub_api-test-platform-code_PR-292/env/src/django-jenkins/django_jenkins/tasks/with_coverage.py", line 29, in save
    self.coverage.stop()
  File "/tmp/jenkins-slave/workspace/ub_api-test-platform-code_PR-292/env/src/django-jenkins/django_jenkins/tasks/with_coverage.py", line 55, in get_morfs
    return [filename for filename in coverage.data.measured_files()
AttributeError: 'Coverage' object has no attribute 'data'
```