### PR TITLE
Use default timeout for Newman runner

### DIFF
--- a/src/vng/utils/newman.py
+++ b/src/vng/utils/newman.py
@@ -19,7 +19,6 @@ class NewmanManager:
     newman_path = os.path.join(settings.BASE_DIR, 'node_modules', 'newman', 'bin', 'newman.js')
     RUN_REPORT = ('NODE_OPTIONS="--max-old-space-size=2048" '
                        '{} run --reporters "htmlextra,json" {} '
-                       '--timeout-request 50000 '
                        '--reporter-htmlextra-darkTheme '
                        '--reporter-htmlextra-testPaging '
                        '--reporter-htmlextra-title '


### PR DESCRIPTION
@alextreme de versie van newman die wij gebruiken heeft al een default timeout van oneindig (https://github.com/postmanlabs/newman/pull/1630/files) en de zgw APIs hebben die blijkbaar nodig, dus bij deze :p 