### PR TITLE
Show only custom permissions as available in guardian admin for API

### DIFF
--- a/src/vng/servervalidation/admin.py
+++ b/src/vng/servervalidation/admin.py
@@ -8,6 +8,8 @@ from guardian.admin import GuardedModelAdmin
 
 from vng.testsession.models import SessionType
 
+from .forms import CustomAdminUserObjectPermissionsForm, CustomAdminGroupObjectPermissionsForm
+
 def get_all_fields(mo):
     l = [field.name for field in mo._meta.fields]
     l.remove('id')
@@ -66,6 +68,13 @@ class APIAdmin(GuardedModelAdmin):
         permission_codes = [code for code, _ in obj._meta.permissions]
         context["model_perms"] = context["model_perms"].filter(codename__in=permission_codes)
         return context
+
+    def get_obj_perms_manage_group_form(self, request):
+        return CustomAdminGroupObjectPermissionsForm
+
+    def get_obj_perms_manage_user_form(self, request):
+        return CustomAdminGroupObjectPermissionsForm
+
 
 @admin.register(model.PostmanTest)
 class PostmanTestAdmin(AdminChangeLinksMixin, OrderedModelAdmin):

--- a/src/vng/servervalidation/forms.py
+++ b/src/vng/servervalidation/forms.py
@@ -7,6 +7,7 @@ from django import forms
 from filer.models.filemodels import File
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
+from guardian.admin import AdminUserObjectPermissionsForm, AdminGroupObjectPermissionsForm
 from django.forms.models import inlineformset_factory
 
 from tinymce.widgets import TinyMCE
@@ -211,3 +212,22 @@ class EnvironmentUpdateForm(forms.ModelForm):
     class Meta:
         model = Environment
         fields = ['name']
+
+
+class CustomPermissionChoicesMixin:
+    def get_obj_perms_field_choices(self):
+        """
+        Show only the custom permissions as the available object permissions
+        """
+        choices = super().get_obj_perms_field_choices()
+        permission_codes = [code for code, _ in self.obj._meta.permissions]
+        choices = [(perm, label) for perm, label in choices if perm in permission_codes]
+        return choices
+
+
+class CustomAdminUserObjectPermissionsForm(CustomPermissionChoicesMixin, AdminUserObjectPermissionsForm):
+    pass
+
+
+class CustomAdminGroupObjectPermissionsForm(CustomPermissionChoicesMixin, AdminGroupObjectPermissionsForm):
+    pass


### PR DESCRIPTION
issue https://github.com/VNG-Realisatie/api-test-platform/issues/335

zodat permissies zoals `add an API` er niet bijstaan, want dat kan toch niet via het web interface