### PR TITLE
Disable JSON schema validation in postman collection generator for now

### DIFF
--- a/src/vng/servervalidation/tests/test_postman_collection_generator.py
+++ b/src/vng/servervalidation/tests/test_postman_collection_generator.py
@@ -30,21 +30,23 @@ class PostmanCollectionGeneratorTests(WebTest):
         self.assertIn("script", event)
 
         # Two testscripts, one for status code and one for body schema
-        self.assertEqual(len(event["script"]["exec"]), 2)
+        self.assertEqual(len(event["script"]["exec"]), 1)
         self.assertEqual(event["script"]["exec"][0], 'pm.test("Alle BESLUITen opvragen. geeft 200", \
 function() {\n\tpm.response.to.have.status(200);\n});')
-        self.assertEqual(event["script"]["exec"][1], 'pm.test("Alle BESLUITen opvragen. \
-heeft valide body", function() {\n\tconst Ajv = require(\'ajv\');\n\tvar ajv = \
-new Ajv({logger: console});\n\tvar schema = {"properties": {"count": {"type": "integer"}, \
-"results": {"items": {"properties": {"verantwoordelijkeOrganisatie": {"type": "string"}, "besluittype": \
-{"format": "uri"}, "datum": {"format": "date"}, "ingangsdatum": {"format": "date"}, "url": \
-{"format": "uri"}, "identificatie": {"type": "string"}, "zaak": {"format": "uri"}, \
-"toelichting": {"type": "string"}, "bestuursorgaan": {"type": "string"}, "vervaldatum": \
-{"format": "date"}, "vervalreden": {"type": "string"}, "vervalredenWeergave": \
-{"type": "string"}, "publicatiedatum": {"format": "date"}, "verzenddatum": \
-{"format": "date"}, "uiterlijkeReactiedatum": {"format": "date"}}}}, "next": \
-{"format": "uri"}, "previous": {"format": "uri"}}};\n\tpm.expect(ajv.validate\
-(schema, pm.response.json())).to.be.true;\n});')
+
+        # TODO Should be enabled once JSON schema generation is fixed
+#         self.assertEqual(event["script"]["exec"][1], 'pm.test("Alle BESLUITen opvragen. \
+# heeft valide body", function() {\n\tconst Ajv = require(\'ajv\');\n\tvar ajv = \
+# new Ajv({logger: console});\n\tvar schema = {"properties": {"count": {"type": "integer"}, \
+# "results": {"items": {"properties": {"verantwoordelijkeOrganisatie": {"type": "string"}, "besluittype": \
+# {"format": "uri"}, "datum": {"format": "date"}, "ingangsdatum": {"format": "date"}, "url": \
+# {"format": "uri"}, "identificatie": {"type": "string"}, "zaak": {"format": "uri"}, \
+# "toelichting": {"type": "string"}, "bestuursorgaan": {"type": "string"}, "vervaldatum": \
+# {"format": "date"}, "vervalreden": {"type": "string"}, "vervalredenWeergave": \
+# {"type": "string"}, "publicatiedatum": {"format": "date"}, "verzenddatum": \
+# {"format": "date"}, "uiterlijkeReactiedatum": {"format": "date"}}}}, "next": \
+# {"format": "uri"}, "previous": {"format": "uri"}}};\n\tpm.expect(ajv.validate\
+# (schema, pm.response.json())).to.be.true;\n});')
 
     def test_generate_collection_from_invalid_oas(self):
         response = self.app.get(reverse("server_run:collection_generator"), user=self.user)

--- a/src/vng/utils/newman.py
+++ b/src/vng/utils/newman.py
@@ -138,20 +138,21 @@ def generate_testscript(item, openapi_types, openapi_format):
             "type": "text/javascript"
         }
     ]
-    if status_code != 204:
-        infinite_dict = lambda: defaultdict(infinite_dict)
-        schema = infinite_dict()
-        if item["response"][0]["body"]:
-            valid_body = json.loads(item["response"][0]["body"])
-            generate_schema(schema, valid_body, openapi_types, openapi_format)
+    # TODO fix json schema generation
+    # if status_code != 204:
+    #     infinite_dict = lambda: defaultdict(infinite_dict)
+    #     schema = infinite_dict()
+    #     if item["response"][0]["body"]:
+    #         valid_body = json.loads(item["response"][0]["body"])
+    #         generate_schema(schema, valid_body, openapi_types, openapi_format)
 
-            validate_body_script = ("pm.test(\"{} heeft valide body\", function() {{\n"
-                                "\tconst Ajv = require('ajv');\n"
-                                "\tvar ajv = new Ajv({{logger: console}});\n"
-                                "\tvar schema = {};\n"
-                                "\tpm.expect(ajv.validate(schema, pm.response.json())).to.be.true;\n"
-                                "}});").format(item['name'], json.dumps(schema))
-            event[0]["script"]["exec"].append(validate_body_script)
+    #         validate_body_script = ("pm.test(\"{} heeft valide body\", function() {{\n"
+    #                             "\tconst Ajv = require('ajv');\n"
+    #                             "\tvar ajv = new Ajv({{logger: console}});\n"
+    #                             "\tvar schema = {};\n"
+    #                             "\tpm.expect(ajv.validate(schema, pm.response.json())).to.be.true;\n"
+    #                             "}});").format(item['name'], json.dumps(schema))
+    #         event[0]["script"]["exec"].append(validate_body_script)
     return event
 
 def generate_schema(schema, body, openapi_types, openapi_format):


### PR DESCRIPTION
Ik dacht dat ik het JSON schema kon afleiden uit de response bodies die Postman genereert uit de OAS, maar die bodies blijken niet te kloppen, omdat de converter van postman het type property weglaat als format gedefinieerd is, en nullable properties worden niet afgehandeld